### PR TITLE
feat(layout): improvement layout

### DIFF
--- a/components/layout/Aside.vue
+++ b/components/layout/Aside.vue
@@ -21,7 +21,7 @@
         </NuxtLink>
       </li>
     </ul>
-    <LayoutAsideTree :links="tree" :level="0" class="pl-3 pt-4" />
+    <LayoutAsideTree :links="tree" :level="0" class="pt-4" />
   </UiScrollArea>
 </template>
 
@@ -37,7 +37,6 @@ const tree = computed(() => {
   const path = route.path.split('/');
   if (config.value.aside.useLevel) {
     const leveledPath = path.splice(0, 2).join('/');
-
     const dir = navDirFromPath(leveledPath, navigation.value);
     return dir ?? [];
   }

--- a/components/layout/AsideTree.vue
+++ b/components/layout/AsideTree.vue
@@ -1,5 +1,5 @@
 <template>
-  <ul class="py-2.5" :class="[level > 0 && 'border-l']">
+  <ul class="py-2.5" :class="[level > 0 && 'border-l ml-1.5']">
     <template v-for="link in links" :key="link._id">
       <LayoutAsideTreeItem
         :link="link"

--- a/components/layout/Header.vue
+++ b/components/layout/Header.vue
@@ -1,7 +1,7 @@
 <template>
   <header class="sticky z-40 top-0 bg-background/80 backdrop-blur-lg lg:border-b">
-    <div class="container px-4 md:px-8 flex h-14 max-w-screen-2xl items-center border-b lg:border-none gap-2 justify-between">
-      <LayoutHeaderLogo class="hidden md:flex flex-1" />
+    <div class="container px-4 lg:px-8 flex h-14 items-center border-b lg:border-none gap-2 justify-between">
+      <LayoutHeaderLogo class="hidden lg:flex flex-1" />
       <LayoutMobileNav />
       <LayoutHeaderNav class="hidden lg:flex flex-1" />
       <div class="flex flex-1 justify-end gap-2">

--- a/components/layout/Header.vue
+++ b/components/layout/Header.vue
@@ -1,10 +1,10 @@
 <template>
   <header class="sticky z-40 top-0 bg-background/80 backdrop-blur-lg lg:border-b">
-    <div class="container px-4 lg:px-8 flex h-14 items-center border-b lg:border-none gap-2 justify-between">
+    <div class="container px-4 lg:px-8 flex h-14 items-center border-b lg:border-none gap-2">
       <LayoutHeaderLogo class="hidden lg:flex flex-1" />
       <LayoutMobileNav />
-      <LayoutHeaderNav class="hidden lg:flex flex-1" />
-      <div class="flex flex-1 justify-end gap-2">
+      <LayoutHeaderNav class="hidden lg:flex" />
+      <div class="flex justify-end gap-2 flex-1">
         <LayoutSearchButton v-if="!config.search.inAside" />
         <div class="flex">
           <DarkModeToggle v-if="config.header.darkModeToggle" />

--- a/components/layout/Header/Logo.vue
+++ b/components/layout/Header/Logo.vue
@@ -1,11 +1,13 @@
 <template>
-  <NuxtLink v-if="logo.light && logo.dark" to="/" class="flex">
-    <NuxtImg :src="logo.light" class="dark:hidden h-7" />
-    <NuxtImg :src="logo.dark" class="hidden dark:block h-7" />
-    <span v-if="showTitle && title" class="self-center font-bold ml-3">
-      {{ title }}
-    </span>
-  </NuxtLink>
+  <div>
+    <NuxtLink v-if="logo.light && logo.dark" to="/" class="flex">
+      <NuxtImg :src="logo.light" class="dark:hidden h-7" />
+      <NuxtImg :src="logo.dark" class="hidden dark:block h-7" />
+      <span v-if="showTitle && title" class="self-center font-bold ml-3">
+        {{ title }}
+      </span>
+    </NuxtLink>
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/components/layout/MobileNav.vue
+++ b/components/layout/MobileNav.vue
@@ -4,7 +4,7 @@
       <UiButton
         variant="ghost"
         size="icon"
-        class="md:hidden"
+        class="lg:hidden"
       >
         <Icon name="lucide:menu" size="18" />
       </UiButton>

--- a/components/layout/SearchButton.vue
+++ b/components/layout/SearchButton.vue
@@ -3,7 +3,7 @@
     v-if="enable"
     variant="outline"
     class="pr-1.5 h-8 self-center w-full rounded-md"
-    :class="[inAside ? 'mb-4' : 'md:w-40 lg:w-64']"
+    :class="[inAside ? 'mb-4' : 'lg:w-64']"
     @click="isOpen = true"
   >
     <span class="text-muted-foreground overflow-hidden mr-auto">

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -1,8 +1,8 @@
 <template>
   <LayoutHeader />
   <div class="border-b min-h-screen">
-    <div class="container px-4 md:px-8 flex-1 items-start md:grid md:grid-cols-[220px_minmax(0,1fr)] md:gap-6 lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-10">
-      <aside class="fixed top-[102px] lg:top-[60px] z-30 -ml-2 hidden h-[calc(100vh-3.5rem)] w-full shrink-0 md:sticky md:block overflow-y-auto">
+    <div class="container px-4 lg:px-8 flex-1 items-start lg:grid lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-10">
+      <aside class="top-[3.5rem] z-30 -ml-2 hidden h-[calc(100vh-3.5rem)] w-full shrink-0 lg:sticky lg:block overflow-y-auto">
         <LayoutAside :is-mobile="false" />
       </aside>
       <main class="relative py-6" :class="[config.toc.enable && 'lg:gap-10 lg:py-8 lg:grid lg:grid-cols-[1fr_200px]']">
@@ -36,7 +36,7 @@
           <LayoutPrevNext />
         </div>
         <div v-if="config.toc.enable" class="hidden text-sm lg:block">
-          <div class="sticky top-[90px] h-[calc(100vh-3.5rem)] overflow-hidden">
+          <div class="sticky lg:top-[calc(3.5rem+2rem)] h-[calc(100vh-3.5rem)] overflow-hidden">
             <LayoutToc :is-small="false" />
           </div>
         </div>


### PR DESCRIPTION
- show `LayoutAside` only on screen lg
- remove 'max-w-screen-2xl' and only use 'container'

Screenshot: 
<img width="1800" alt="image" src="https://github.com/ZTL-UwU/shadcn-docs-nuxt/assets/31064578/43e4eadb-c266-4fdc-8409-a8f11dd34314">
<img width="1178" alt="image" src="https://github.com/ZTL-UwU/shadcn-docs-nuxt/assets/31064578/11d95842-ba70-4a81-a1b9-1c26f1c7e286">
