### PR TITLE
fix(navbar): hydration children mismatch

### DIFF
--- a/components/layout/Header/Nav.vue
+++ b/components/layout/Header/Nav.vue
@@ -25,11 +25,11 @@
             </ul>
           </UiNavigationMenuContent>
         </template>
-        <NuxtLink v-else :to="item.to" :target="item.target" class="relative!">
+        <NuxtLink v-else :to="item.to" :target="item.target">
           <Icon name="lucide:arrow-up-right" class="absolute right-2 top-2 text-muted-foreground" size="13" />
-          <UiNavigationMenuLink class="pr-6 font-semibold bg-transparent" :class="navigationMenuTriggerStyle()">
+          <div class="pr-6 font-semibold bg-transparent" :class="navigationMenuTriggerStyle()">
             {{ item.title }}
-          </UiNavigationMenuLink>
+          </div>
         </NuxtLink>
       </UiNavigationMenuItem>
     </UiNavigationMenuList>


### PR DESCRIPTION
Nesting HTML elements that aren't allowed within their ancestor HTML element.

`<a>` cannot be within another `<a>`. 

Warning:
<img width="1201" alt="image" src="https://github.com/ZTL-UwU/shadcn-docs-nuxt/assets/31064578/ae8f38d6-d63c-40ca-ad4b-f17f6acc39df">

Because:
<img width="842" alt="image" src="https://github.com/ZTL-UwU/shadcn-docs-nuxt/assets/31064578/54c294b0-69ef-4773-82d4-bba3fca238bd">
