### PR TITLE
Fixed typo in carbonads enable

### DIFF
--- a/content/3.api/1.configuration/5.carbon-ads.md
+++ b/content/3.api/1.configuration/5.carbon-ads.md
@@ -12,7 +12,7 @@ export default defineAppConfig({
     toc: {
       enable: true,
       carbonAds: {
-        enabled: true,
+        enable: true,
         code: 'your-carbon-code',
         placement: 'your-carbon-placement',
         format: 'your-carbon-format', // defaults to 'cover'


### PR DESCRIPTION
In docs, it's mentioned `enabled` but the component uses `enable` to check if carbon ads is enabled.