### PR TITLE
fix: config is merged incorrectly

### DIFF
--- a/composables/useConfig.ts
+++ b/composables/useConfig.ts
@@ -1,4 +1,11 @@
-import { defu } from 'defu';
+import { createDefu } from 'defu';
+
+const customDefu = createDefu((obj, key, value) => {
+  if (Array.isArray(value) && value.every((x: any) => typeof x === 'string')) {
+    obj[key] = value;
+    return true;
+  }
+});
 
 const defaultConfig: DefaultConfig = {
   site: {
@@ -141,7 +148,7 @@ export function useConfig() {
 
   return computed(
     () => {
-      const processedConfig = defu(appConfig.value, defaultConfig);
+      const processedConfig = customDefu(appConfig.value, defaultConfig);
       const header = processedConfig.header;
       const main = processedConfig.main;
       const aside = processedConfig.aside;


### PR DESCRIPTION
Resolves #76

As a suggestion to solve the problem, I have created a custom defu. Here are the results and the matching test code.

Current result:
```JSON
{
  "main": {
    "showTitle": true,
    "padded": false,
    "pm": [
      "npm",
      "pnpm",
      "npm",
      "pnpm",
      "bun",
      "yarn"
    ]
  }
}
```
After fix:
```JSON
{
  "main": {
    "showTitle": true,
    "padded": false,
    "pm": [
      "npm",
      "pnpm"
    ]
  }
}
```

The test code:
```TS
const defaultConfig = {
  main: {
    showTitle: true,
    padded: true,
    pm: ['npm', 'pnpm', 'bun', 'yarn'],
  }
};
const localConfig = {
  main: {
    padded: false,
    pm: ['npm', 'pnpm'],
  }
};

const current = defu(localConfig, defaultConfig);
const afterFix = customDefu(localConfig, defaultConfig);
console.info('current', current);
console.info('afterFix', afterFix);
```