### PR TITLE
Fixed annoying ES module warning

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,3 @@
-import type { Config } from 'tailwindcss';
 import animate from 'tailwindcss-animate';
 
 export default {
@@ -86,4 +85,4 @@ export default {
   },
 
   plugins: [animate],
-} satisfies Config;
+};


### PR DESCRIPTION
**Issue:**

```
ERROR (node:53633) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(Use node --trace-warnings ... to show where the warning was created)
```

**Reason:**
Simplifying the tailwind configuration by eliminating TypeScript removes the annoying ES module warning.