### PR TITLE
fix: removed annoying warning for the mobile navbar

### DIFF
--- a/components/layout/MobileNav.vue
+++ b/components/layout/MobileNav.vue
@@ -12,6 +12,8 @@
     <UiSheetContent side="left" class="pr-0">
       <LayoutHeaderLogo />
       <LayoutAside is-mobile />
+      <UiDialogTitle class="sr-only" />
+      <UiDialogDescription class="sr-only" />
     </UiSheetContent>
   </UiSheet>
 </template>


### PR DESCRIPTION
It's not actually a fix, but I just hide it

**Warning:**
```
MobileNav.vue:2 Warning: DialogContent requires a DialogTitle for the component to be accessible for screen reader users.

If you want to hide the DialogTitle, you can wrap it with our VisuallyHidden component.

For more information, see https://www.radix-vue.com/components/dialog.html#title
```