### PR TITLE
feat(i18n): add ru ko hindi ui translations

### DIFF
--- a/i18n/i18n.config.ts
+++ b/i18n/i18n.config.ts
@@ -320,7 +320,7 @@ export default defineI18nConfig(() => ({
       'required': '필수',
     },
 
-    'hindi': {
+    'hi': {
       // Search
       'Search...': 'खोजें...',
       'Search documentation...': 'दस्तावेज़ खोजें...',

--- a/www/content/1.getting-started/5.upgrade.md
+++ b/www/content/1.getting-started/5.upgrade.md
@@ -40,6 +40,9 @@ Currently supported UI locales are:
 - `zh-CN` (简体中文)
 - `zh-TW` (繁體中文)
 - `ja` (日本語)
+- `ru` (Русский)
+- `ko` (한국어)
+- `hi` (हिन्दी)
 
 ::alert{icon="lucide:git-pull-request-arrow" to="https://github.com/ZTL-UwU/shadcn-docs-nuxt/issues/125"}
 If you want to add more UI locales, feel free to contribute to the project.

--- a/www/content/3.api/1.configuration/6.i18n.md
+++ b/www/content/3.api/1.configuration/6.i18n.md
@@ -84,6 +84,9 @@ The UI locale will follow the selected language in the language switcher. UI tra
 - `zh-CN` (简体中文)
 - `zh-TW` (繁體中文)
 - `ja` (日本語)
+- `ru` (Русский)
+- `ko` (한국어)
+- `hi` (हिन्दी)
 
 ::alert{icon="lucide:git-pull-request-arrow" to="https://github.com/ZTL-UwU/shadcn-docs-nuxt/issues/125"}
 If you want to add more UI locales, feel free to contribute to the project.

--- a/www/content/fr/1.getting-started/5.upgrade.md
+++ b/www/content/fr/1.getting-started/5.upgrade.md
@@ -40,11 +40,13 @@ Locales d'interface actuellement prises en charge:
 - `zh-CN` (简体中文)
 - `zh-TW` (繁體中文)
 - `ja` (日本語)
+- `ru` (Русский)
+- `ko` (한국어)
+- `hi` (हिन्दी)
 
 ::alert{icon="lucide:git-pull-request-arrow" to="https://github.com/ZTL-UwU/shadcn-docs-nuxt/issues/125"}
 Si vous souhaitez ajouter d'autres locales, n'hésitez pas à contribuer au projet.
 ::
-
 
 #### Mettez à jour Tailwind CSS
 

--- a/www/content/fr/3.api/1.configuration/6.i18n.md
+++ b/www/content/fr/3.api/1.configuration/6.i18n.md
@@ -86,6 +86,9 @@ La langue de l'interface utilisateur suivra la langue sélectionnée dans le sé
 - `zh-CN` (简体中文)
 - `zh-TW` (繁體中文)
 - `ja` (日本語)
+- `ru` (Русский)
+- `ko` (한국어)
+- `hi` (हिन्दी)
 
 ::alert{icon="lucide:git-pull-request-arrow" to="https://github.com/ZTL-UwU/shadcn-docs-nuxt/issues/125"}
 Si vous souhaitez ajouter d'autres langues, n'hésitez pas à contribuer au projet.


### PR DESCRIPTION
- Added Russian, Korean and Hindi  translations . 
- Added to this file with similar format:
https://github.com/ZTL-UwU/shadcn-docs-nuxt/blob/beed7c8a9fada302c2336af90208876b18615a2b/i18n/i18n.config.ts#L6-L50 

#125 

Thank you !