### PR TITLE
feat(i18n): add bn (Bangla) ui translation

### DIFF
--- a/i18n/i18n.config.ts
+++ b/i18n/i18n.config.ts
@@ -365,5 +365,50 @@ export default defineI18nConfig(() => ({
       // Field
       'required': 'आवश्यक',
     },
+    'bn': {
+      // Search
+      'Search...': 'অনুসন্ধান...',
+      'Search documentation...': 'ডকুমেন্টেশন খুঁজুন...',
+      'No results found.': 'কোন ফলাফল পাওয়া যায়নি।',
+
+      // TOC
+      'On This Page': 'এই পৃষ্ঠায়',
+
+      // Search command
+      'Light': 'আলো',
+      'Dark': 'অন্ধকার',
+      'System': 'सिस्टम',
+
+      // Doc footer
+      'Edit this page': 'এই পাতাটি সম্পাদনা করুন',
+      'Back to Top': 'উপরে ফিরে যান',
+
+      // Collapse Code
+      'Expand': 'প্রসারিত করুন',
+      'Collapse': 'সঙ্কুচিত করুন',
+
+      // Language Switcher
+      'Language': 'ভাষা',
+      'Choose your language': 'আপনার ভাষা বেছে নিন',
+
+      // Theme Switcher
+      'Customize': 'কাস্টমাইজ করুন',
+      'Pick a style and color for the docs.': 'ডকুমেন্টেশন জন্য একটি স্টাইল এবং রঙ বেছে নিন।',
+      'Color': 'রঙ',
+      'Radius': 'ব্যাসার্ধ',
+      'Theme': 'থিম',
+
+      // Copy Code
+      'Copied to clipboard!': 'ক্লিপবোর্ডে কপি করা হয়েছে!',
+
+      // Carbon Ads
+      'Please support us by disabling your ad blocker.': 'আমাদের সমর্থন করার জন্য অনুগ্রহ করে আপনার ad blocker নিষ্ক্রিয় করুন।',
+
+      // Read More
+      'Read more at': 'আরও পড়ুন:',
+
+      // Field
+      'required': 'অবশ্যক',
+    },
   },
 }));

--- a/www/content/1.getting-started/5.upgrade.md
+++ b/www/content/1.getting-started/5.upgrade.md
@@ -43,6 +43,7 @@ Currently supported UI locales are:
 - `ru` (Русский)
 - `ko` (한국어)
 - `hi` (हिन्दी)
+- `bn` (বাংলা)
 
 ::alert{icon="lucide:git-pull-request-arrow" to="https://github.com/ZTL-UwU/shadcn-docs-nuxt/issues/125"}
 If you want to add more UI locales, feel free to contribute to the project.

--- a/www/content/3.api/1.configuration/6.i18n.md
+++ b/www/content/3.api/1.configuration/6.i18n.md
@@ -87,6 +87,7 @@ The UI locale will follow the selected language in the language switcher. UI tra
 - `ru` (Русский)
 - `ko` (한국어)
 - `hi` (हिन्दी)
+- `bn` (বাংলা)
 
 ::alert{icon="lucide:git-pull-request-arrow" to="https://github.com/ZTL-UwU/shadcn-docs-nuxt/issues/125"}
 If you want to add more UI locales, feel free to contribute to the project.

--- a/www/content/fr/1.getting-started/5.upgrade.md
+++ b/www/content/fr/1.getting-started/5.upgrade.md
@@ -43,6 +43,7 @@ Locales d'interface actuellement prises en charge:
 - `ru` (Русский)
 - `ko` (한국어)
 - `hi` (हिन्दी)
+- `bn` (বাংলা)
 
 ::alert{icon="lucide:git-pull-request-arrow" to="https://github.com/ZTL-UwU/shadcn-docs-nuxt/issues/125"}
 Si vous souhaitez ajouter d'autres locales, n'hésitez pas à contribuer au projet.

--- a/www/content/fr/3.api/1.configuration/6.i18n.md
+++ b/www/content/fr/3.api/1.configuration/6.i18n.md
@@ -89,6 +89,7 @@ La langue de l'interface utilisateur suivra la langue sélectionnée dans le sé
 - `ru` (Русский)
 - `ko` (한국어)
 - `hi` (हिन्दी)
+- `bn` (বাংলা)
 
 ::alert{icon="lucide:git-pull-request-arrow" to="https://github.com/ZTL-UwU/shadcn-docs-nuxt/issues/125"}
 Si vous souhaitez ajouter d'autres langues, n'hésitez pas à contribuer au projet.


### PR DESCRIPTION
https://github.com/ZTL-UwU/shadcn-docs-nuxt/issues/125
Added Bangla translations with  similar format  of this file:
[shadcn-docs-nuxt/i18n/i18n.config.ts](https://github.com/ZTL-UwU/shadcn-docs-nuxt/blob/beed7c8a9fada302c2336af90208876b18615a2b/i18n/i18n.config.ts#L6-L50)

```json
    'bn': {
      // Search
      'Search...': 'অনুসন্ধান...',
      'Search documentation...': 'ডকুমেন্টেশন খুঁজুন...',
      'No results found.': 'কোন ফলাফল পাওয়া যায়নি।',

      // TOC
      'On This Page': 'এই পৃষ্ঠায়',

      // Search command
      'Light': 'আলো',
      'Dark': 'অন্ধকার',
      'System': 'सिस्टम',
...
```
Thanks