### PR TITLE
feat(i18n): add `km` (ភាសាខ្មែរ) ui translation.

### DIFF
--- a/i18n/i18n.config.ts
+++ b/i18n/i18n.config.ts
@@ -228,6 +228,51 @@ export default defineI18nConfig(() => ({
       // Field
       'required': '必須',
     },
+    'km': {
+      // Search
+      'Search...': 'ស្វែងរក...',
+      'Search documentation...': 'ស្វែងរកឯកសារ...',
+      'No results found.': 'មិនមានលទ្ធផលទេ',
+
+      // TOC
+      'On This Page': 'នៅលើទំព័រនេះ',
+
+      // Search command
+      'Light': 'ផ្ទៃភ្លឺ',
+      'Dark': 'ផ្ទៃងងឹត',
+      'System': 'តាមប្រព័ន្ធ',
+
+      // Doc footer
+      'Edit this page': 'កែសម្រួលទំព័រនេះ',
+      'Back to Top': 'រំកិលទៅខាងលើវិញ',
+
+      // Collapse Code
+      'Expand': 'ពន្លាតបង្ហាញ',
+      'Collapse': 'បង្រួម',
+
+      // Language Switcher
+      'Language': 'ភាសា',
+      'Choose your language': 'ជ្រើសរើសភាសារបស់អ្នក',
+
+      // Theme Switcher
+      'Customize': 'ប្ដូរតាមចំណង់ចំណូលចិត្ត',
+      'Pick a style and color for the docs.': 'ជ្រើសរើសរចនាប័ទ្ម និងពណ៌សម្រាប់ឯកសារ',
+      'Color': 'ពណ៌',
+      'Radius': 'កាំកំណោង',
+      'Theme': 'ផ្ទៃស្បែក',
+
+      // Copy Code
+      'Copied to clipboard!': 'បានចម្លងទុកទៅកាន់ក្តារចម្លង!',
+
+      // Carbon Ads
+      'Please support us by disabling your ad blocker.': 'សូមគាំទ្រពួកយើងដោយការបិទកម្មវិធីរាំងខ្ទប់ពាណិជ្ជកម្ម',
+
+      // Read More
+      'Read more at': 'អានបន្ថែមនៅ',
+
+      // Field
+      'required': 'តម្រូវឲ្យមានជាដាច់ខាត',
+    },
     'ru': {
       // Search
       'Search...': 'Поиск...',

--- a/www/content/1.getting-started/5.upgrade/1.v1.md
+++ b/www/content/1.getting-started/5.upgrade/1.v1.md
@@ -45,6 +45,7 @@ Currently supported UI locales are:
 - `zh-CN` (简体中文)
 - `zh-TW` (繁體中文)
 - `ja` (日本語)
+- `km` (ភាសាខ្មែរ)
 - `ru` (Русский)
 - `ko` (한국어)
 - `hi` (हिन्दी)

--- a/www/content/4.blog/1.v1.md
+++ b/www/content/4.blog/1.v1.md
@@ -183,6 +183,7 @@ Currently supported UI locales are:
 - `zh-CN` (简体中文)
 - `zh-TW` (繁體中文)
 - `ja` (日本語)
+- `km` (ភាសាខ្មែរ)
 - `ru` (Русский)
 - `ko` (한국어)
 - `hi` (हिन्दी)

--- a/www/content/fr/1.getting-started/5.upgrade/1.v1.md
+++ b/www/content/fr/1.getting-started/5.upgrade/1.v1.md
@@ -45,6 +45,7 @@ Locales d'interface actuellement prises en charge:
 - `zh-CN` (简体中文)
 - `zh-TW` (繁體中文)
 - `ja` (日本語)
+- `km` (ភាសាខ្មែរ)
 - `ru` (Русский)
 - `ko` (한국어)
 - `hi` (हिन्दी)

--- a/www/content/fr/4.blog/v1.md
+++ b/www/content/fr/4.blog/v1.md
@@ -183,6 +183,7 @@ Les langues d'interface utilisateur actuellement prises en charge sont :
 - `zh-CN` (简体中文)
 - `zh-TW` (繁體中文)
 - `ja` (日本語)
+- `km` (ភាសាខ្មែរ)
 - `ru` (Русский)
 - `ko` (한국어)
 - `hi` (हिन्दी)


### PR DESCRIPTION
[#125](https://github.com/ZTL-UwU/shadcn-docs-nuxt/issues/125)
Added Khmer (ភាសាខ្មែរ) translations to `i18n.config.ts` file and in documentation.
[shadcn-docs-nuxt/i18n/i18n.config.ts](https://github.com/ZTL-UwU/shadcn-docs-nuxt/blob/beed7c8a9fada302c2336af90208876b18615a2b/i18n/i18n.config.ts#L6-L50)