### PR TITLE
chore: remove duplicated i18n `km (ភាសាខ្មែរ)` in the documentation.

### DIFF
--- a/www/content/3.api/1.configuration/6.i18n.md
+++ b/www/content/3.api/1.configuration/6.i18n.md
@@ -83,7 +83,6 @@ The UI locale will follow the selected language in the language switcher. UI tra
 - `fr` (Français)
 - `zh-CN` (简体中文)
 - `zh-TW` (繁體中文)
-- `km` (ភាសាខ្មែរ)
 - `ja` (日本語)
 - `km` (ភាសាខ្មែរ)
 - `ru` (Русский)


### PR DESCRIPTION
https://shadcn-docs-nuxt.vercel.app/api/configuration/i18n#ui-translation