### PR TITLE
fix: close search dialog on route change

### DIFF
--- a/components/layout/SearchDialog.vue
+++ b/components/layout/SearchDialog.vue
@@ -147,4 +147,13 @@ function handleNavigate(delta: -1 | 1) {
   if (activeSelect.value + delta >= 0 && activeSelect.value + delta < searchResult.value.length)
     activeSelect.value += delta;
 }
+
+const router = useRouter();
+
+watch(
+  () => router.currentRoute.value,
+  () => {
+    open.value = false;
+  }
+);
 </script>

--- a/components/layout/SearchDialog.vue
+++ b/components/layout/SearchDialog.vue
@@ -154,6 +154,6 @@ watch(
   () => router.currentRoute.value,
   () => {
     open.value = false;
-  }
+  },
 );
 </script>


### PR DESCRIPTION
Close search dialog on route change

Before

https://github.com/user-attachments/assets/10fb7f11-8708-4516-ae5e-5eec1f17a03e

After

https://github.com/user-attachments/assets/cfef1a0b-8886-4e91-b701-acf80e17fe92

