### PR TITLE
fix: resolve hero button wrapping & mobile styles

### DIFF
--- a/components/content/Hero.vue
+++ b/components/content/Hero.vue
@@ -24,7 +24,7 @@
       <ContentSlot :use="$slots.description" unwrap="p" />
     </span>
 
-    <section class="flex w-full items-center justify-center gap-4 py-4 md:pb-10">
+    <section class="flex w-full flex-wrap items-center justify-center gap-4 py-4 md:pb-10">
       <NuxtLinkLocale
         v-for="(action, i) in actions"
         :key="i"

--- a/components/layout/Footer.vue
+++ b/components/layout/Footer.vue
@@ -3,17 +3,19 @@
     <div class="container flex flex-col items-center justify-between gap-2 md:h-24 md:flex-row">
       <MDC :value="$t(footer.credits)" class="text-sm" />
       <span class="flex-1" />
-      <NuxtLinkLocale
-        v-for="(link, i) in footer.links"
-        :key="i"
-        :to="link?.to"
-        :target="link?.target"
-      >
-        <UiButton variant="ghost" :size="link?.icon && !link?.title ? 'icon' : 'default'" class="flex gap-2">
-          <SmartIcon v-if="link?.icon" :name="link.icon" :size="20" />
-          <span v-if="link?.title">{{ $t(link.title) }}</span>
-        </UiButton>
-      </NuxtLinkLocale>
+      <div class="flex flex-wrap gap-2 justify-center md:justify-end">
+        <NuxtLinkLocale
+          v-for="(link, i) in footer.links"
+          :key="i"
+          :to="link?.to"
+          :target="link?.target"
+        >
+          <UiButton variant="ghost" :size="link?.icon && !link?.title ? 'icon' : 'default'" class="flex gap-2">
+            <SmartIcon v-if="link?.icon" :name="link.icon" :size="20" />
+            <span v-if="link?.title">{{ $t(link.title) }}</span>
+          </UiButton>
+        </NuxtLinkLocale>
+      </div>
     </div>
   </footer>
 </template>


### PR DESCRIPTION
* allow multi-line wrapping for multiple buttons on mobile viewports
* adjust spacing/padding to prevent text overflow or overlap
* ensure readability and tappable area on screens ≤375 px